### PR TITLE
Add gh workflow for gh-pages deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,38 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc/sensitive
+.DS_Store
+.env
+.env.local
+secrets
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# typescript
+*.tsbuildinfo
+
+# editor config
+.vscode/
+
+# generated types
+src/generated/
+cache/

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -38,37 +38,37 @@ jobs:
         env:
           MAPSWIPE_API_ENDPOINT: ${{ vars.MAPSWIPE_API_ENDPOINT }}
 
-      # - name: Build + Test
-      #   run: yarn build
-      #   timeout-minutes: 30
-      #   env:
-      #     # Common
-      #     NODE_OPTIONS: --max_old_space_size=4096
-      #     # App ENV
-      #     MAPSWIPE_COMMUNITY_API_ENDPOINT: ${{ vars.MAPSWIPE_COMMUNITY_API_ENDPOINT }}
-      #     MAPSWIPE_API_ENDPOINT: ${{ vars.MAPSWIPE_API_ENDPOINT }}
+      - name: Build + Test
+        run: yarn build
+        timeout-minutes: 30
+        env:
+          # Common
+          NODE_OPTIONS: --max_old_space_size=4096
+          # App ENV
+          MAPSWIPE_COMMUNITY_API_ENDPOINT: ${{ vars.MAPSWIPE_COMMUNITY_API_ENDPOINT }}
+          MAPSWIPE_API_ENDPOINT: ${{ vars.MAPSWIPE_API_ENDPOINT }}
 
-      # - name: Upload GH artifacts
-      #   uses: actions/upload-pages-artifact@v1
-      #   with:
-      #     path: out/
+      - name: Upload GH artifacts
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: out/
 
-#   deploy:
-#     name: Deploy (GH Page)
-#     needs: test_build
-#     runs-on: ubuntu-latest
-#     if: github.event_name == 'push'
+  deploy:
+    name: Deploy (GH Page)
+    needs: test_build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
 
-#     permissions:
-#       contents: write
-#       id-token: write
-#       pages: write
+    permissions:
+      contents: write
+      id-token: write
+      pages: write
 
-#     environment:
-#       name: github-pages
-#       url: ${{ steps.deployment.outputs.page_url }}
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
 
-#     steps:
-#       - name: Deploy to GitHub Pages 🚀
-#         id: deployment
-#         uses: actions/deploy-pages@v2
+    steps:
+      - name: Deploy to GitHub Pages 🚀
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,9 +5,10 @@ on:
     # NOTE: Don't add other branches
     branches:
       - release
-  schedule:
-    # Runs "At 00:01. every day" (see https://crontab.guru)
-    - cron: '1 0 * * *'
+      - feat/cd  # TODO: REMOVE ME
+  # schedule:
+  #   # Runs "At 00:01. every day" (see https://crontab.guru)
+  #   - cron: '1 0 * * *'
 
 jobs:
   test_build:
@@ -32,37 +33,42 @@ jobs:
       - name: Run yarn install
         run: yarn install
 
-      - name: Build + Test
-        run: yarn build
-        timeout-minutes: 30
+      - name: Download data
+        run: ./scripts/download-data.sh
         env:
-          # Common
-          NODE_OPTIONS: --max_old_space_size=4096
-          # App ENV
-          MAPSWIPE_COMMUNITY_API_ENDPOINT: ${{ vars.MAPSWIPE_COMMUNITY_API_ENDPOINT }}
           MAPSWIPE_API_ENDPOINT: ${{ vars.MAPSWIPE_API_ENDPOINT }}
 
-      - name: Upload GH artifacts
-        uses: actions/upload-pages-artifact@v1
-        with:
-          path: out/
+      # - name: Build + Test
+      #   run: yarn build
+      #   timeout-minutes: 30
+      #   env:
+      #     # Common
+      #     NODE_OPTIONS: --max_old_space_size=4096
+      #     # App ENV
+      #     MAPSWIPE_COMMUNITY_API_ENDPOINT: ${{ vars.MAPSWIPE_COMMUNITY_API_ENDPOINT }}
+      #     MAPSWIPE_API_ENDPOINT: ${{ vars.MAPSWIPE_API_ENDPOINT }}
 
-  deploy:
-    name: Deploy (GH Page)
-    needs: test_build
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push'
+      # - name: Upload GH artifacts
+      #   uses: actions/upload-pages-artifact@v1
+      #   with:
+      #     path: out/
 
-    permissions:
-      contents: write
-      id-token: write
-      pages: write
+#   deploy:
+#     name: Deploy (GH Page)
+#     needs: test_build
+#     runs-on: ubuntu-latest
+#     if: github.event_name == 'push'
 
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+#     permissions:
+#       contents: write
+#       id-token: write
+#       pages: write
 
-    steps:
-      - name: Deploy to GitHub Pages 🚀
-        id: deployment
-        uses: actions/deploy-pages@v2
+#     environment:
+#       name: github-pages
+#       url: ${{ steps.deployment.outputs.page_url }}
+
+#     steps:
+#       - name: Deploy to GitHub Pages 🚀
+#         id: deployment
+#         uses: actions/deploy-pages@v2

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,10 +4,7 @@ on:
   push:
     # NOTE: Don't add other branches
     branches:
-      - develop
-      - feat/cd  # TODO: REMOVE THIS
-
-on:
+      - release
   schedule:
     # Runs "At 00:01. every day" (see https://crontab.guru)
     - cron: '1 0 * * *'
@@ -23,18 +20,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '18.x'
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@v3
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          cache: 'yarn'
+          cache-dependency-path: 'yarn.lock'
 
       - uses: actions/cache@v3
         id: data-cache
@@ -46,14 +33,14 @@ jobs:
         run: yarn install
 
       - name: Build + Test
-        run: yarn export  # TODO: Use yarn build instead
+        run: yarn build
+        timeout-minutes: 30
         env:
           # Common
           NODE_OPTIONS: --max_old_space_size=4096
-          NEXT_PRIVATE_STANDALONE: true
           # App ENV
-          MAPSWIPE_COMMUNITY_API_ENDPOINT: https://api.mapswipe.org/graphql/
-          MAPSWIPE_API_ENDPOINT: https://api-mock-mapswipe.dev.togglecorp.com/api/  # TODO: UPDATE THIS
+          MAPSWIPE_COMMUNITY_API_ENDPOINT: ${{ vars.MAPSWIPE_COMMUNITY_API_ENDPOINT }}
+          MAPSWIPE_API_ENDPOINT: ${{ vars.MAPSWIPE_API_ENDPOINT }}
 
       - name: Upload GH artifacts
         uses: actions/upload-pages-artifact@v1

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,6 +7,11 @@ on:
       - develop
       - feat/cd  # TODO: REMOVE THIS
 
+on:
+  schedule:
+    # Runs "At 00:01. every day" (see https://crontab.guru)
+    - cron: '1 0 * * *'
+
 jobs:
   test_build:
     if: github.event_name == 'push'

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,76 @@
+name: CD
+
+on:
+  push:
+    # NOTE: Don't add other branches
+    branches:
+      - develop
+      - feat/cd  # TODO: REMOVE THIS
+
+jobs:
+  test_build:
+    if: github.event_name == 'push'
+    name: Run Tests + Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v3
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - uses: actions/cache@v3
+        id: data-cache
+        with:
+          path: cache
+          key: data-cache
+
+      - name: Run yarn install
+        run: yarn install
+
+      - name: Build + Test
+        run: yarn export  # TODO: Use yarn build instead
+        env:
+          # Common
+          NODE_OPTIONS: --max_old_space_size=4096
+          NEXT_PRIVATE_STANDALONE: true
+          # App ENV
+          MAPSWIPE_COMMUNITY_API_ENDPOINT: https://api.mapswipe.org/graphql/
+          MAPSWIPE_API_ENDPOINT: https://api-mock-mapswipe.dev.togglecorp.com/api/  # TODO: UPDATE THIS
+
+      - name: Upload GH artifacts
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: out/
+
+  deploy:
+    name: Deploy (GH Page)
+    needs: test_build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+
+    permissions:
+      contents: write
+      id-token: write
+      pages: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages 🚀
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,18 +1,16 @@
 name: CD
 
+# NOTE: Don't update this
 on:
   push:
-    # NOTE: Don't add other branches
     branches:
       - release
-      - feat/cd  # TODO: REMOVE ME
-  # schedule:
-  #   # Runs "At 00:01. every day" (see https://crontab.guru)
-  #   - cron: '1 0 * * *'
+  schedule:
+    # Runs "At 00:01. every day" (see https://crontab.guru)
+    - cron: '1 0 * * *'
 
 jobs:
   test_build:
-    if: github.event_name == 'push'
     name: Run Tests + Build
     runs-on: ubuntu-latest
 
@@ -57,7 +55,6 @@ jobs:
     name: Deploy (GH Page)
     needs: test_build
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
 
     permissions:
       contents: write

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,17 +3,9 @@ FROM node:18-buster-slim
 RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \
         git bash g++ make \
-        # For pre-commit
-        python3-pip \
-    && pip3 install --no-cache-dir setuptools pre-commit \
     # Clean-up
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    # Add /code as safe directory
+    && git config --global --add safe.directory /code
 
 WORKDIR /code
-
-COPY ./package.json /code/package.json
-
-COPY . /code/
-
-# Initial commands runs
-RUN git config --global --add safe.directory /code

--- a/package.json
+++ b/package.json
@@ -12,12 +12,14 @@
         "generate": "graphql-codegen --config codegen.yml && eslint --fix src/generated/types.ts",
         "generate:i18n": "i18next 'src/**/*.{jsx,tsx}' -o 'public/locales/$LOCALE/$NAMESPACE.json'",
         "lint": "next lint",
+        "fetch-data": "env-cmd -f .env.local ./scripts/download-data.sh",
         "css-lint": "stylelint 'src/**/*.css'",
         "typecheck": "tsc",
         "check-unused": "unimported"
     },
     "dependencies": {
         "@togglecorp/fujs": "^2.0.0",
+        "env-cmd": "^10.1.0",
         "gray-matter": "^4.0.3",
         "i18next": "^22.5.1",
         "leaflet": "^1.9.4",

--- a/scripts/download-data.sh
+++ b/scripts/download-data.sh
@@ -37,4 +37,4 @@ download_file $MAPSWIPE_API_ENDPOINT/website-data/project-history.zip project-hi
 download_file $MAPSWIPE_API_ENDPOINT/projects/projects_centroid.geojson projects_centroid.geojson
 download_file $MAPSWIPE_API_ENDPOINT/projects/projects_geom.geojson projects_geom.geojson
 
-unzip -o $DESTINATION_DIR/project-history.zip -d $DESTINATION_DIR
+unzip -o $DESTINATION_DIR/project-history.zip -d $DESTINATION_DIR/project-history

--- a/scripts/download-data.sh
+++ b/scripts/download-data.sh
@@ -24,7 +24,9 @@ function download_file(){
         curl $1 --output $DESTINATION_DIR/$2
     else
         # Check if hash is changed
+        set +e
         echo -n `cat $DESTINATION_DIR/$2.md5` $DESTINATION_DIR/$2 | md5sum --status --check
+        set -e
         if ! [ "$?" == "0" ]; then
             curl $1 --output $DESTINATION_DIR/$2
         fi

--- a/scripts/download-data.sh
+++ b/scripts/download-data.sh
@@ -1,0 +1,40 @@
+#!/bin/bash -e
+
+if [ -z "$MAPSWIPE_API_ENDPOINT" ]
+then
+    echo "Please set \$MAPSWIPE_API_ENDPOINT"
+    exit 1
+fi
+
+# ROOT_DIR = ../
+ROOT_DIR=$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )")
+
+# Remove trailing slash if present
+MAPSWIPE_API_ENDPOINT=${MAPSWIPE_API_ENDPOINT%/}
+
+DESTINATION_DIR=$ROOT_DIR/cache
+mkdir -p $DESTINATION_DIR
+
+function download_file(){
+    echo "Downloading $2: $1"
+    # Download file hash
+    curl -s $1.md5 --output $DESTINATION_DIR/$2.md5
+
+    if [ ! -f $DESTINATION_DIR/$2 ]; then
+        curl $1 --output $DESTINATION_DIR/$2
+    else
+        # Check if hash is changed
+        echo -n `cat $DESTINATION_DIR/$2.md5` $DESTINATION_DIR/$2 | md5sum --status --check
+        if ! [ "$?" == "0" ]; then
+            curl $1 --output $DESTINATION_DIR/$2
+        fi
+    fi
+}
+
+download_file $MAPSWIPE_API_ENDPOINT/website-data/overall-endpoints.csv overall-endpoints.csv
+download_file $MAPSWIPE_API_ENDPOINT/website-data/project-history.zip project-history.zip
+
+download_file $MAPSWIPE_API_ENDPOINT/projects/projects_centroid.geojson projects_centroid.geojson
+download_file $MAPSWIPE_API_ENDPOINT/projects/projects_geom.geojson projects_geom.geojson
+
+unzip -o $DESTINATION_DIR/project-history.zip -d $DESTINATION_DIR

--- a/src/pages/[locale]/data/index.tsx
+++ b/src/pages/[locale]/data/index.tsx
@@ -17,6 +17,7 @@ import {
 import Button from 'components/Button';
 import ProjectTypeIcon from 'components/ProjectTypeIcon';
 import Page from 'components/Page';
+import getFileSizes from 'utils/requests/fileSizes';
 import Card from 'components/Card';
 import KeyFigure from 'components/KeyFigure';
 import Hero from 'components/Hero';
@@ -55,7 +56,6 @@ interface UrlInfo {
     name: DownloadType;
     type: DownloadFileType;
     url: string;
-    ok: boolean;
     size: number;
 }
 
@@ -124,34 +124,30 @@ export const getStaticProps: GetStaticProps<Props> = async (context) => {
     const minArea = Math.min(...areas);
     const maxArea = Math.max(...areas);
 
-    const mapswipeApi = process.env.MAPSWIPE_API_ENDPOINT;
-
     const urls: Omit<UrlInfo, 'size' | 'ok'>[] = [
         {
             name: 'projects_overview',
-            url: `${mapswipeApi}projects/projects.csv`,
+            url: '/api/projects/projects.csv',
             type: 'csv',
         },
         {
             name: 'projects_with_geometry',
-            url: `${mapswipeApi}projects/projects_geom.geojson`,
+            url: '/api/projects/projects_geom.geojson',
             type: 'geojson',
         },
         {
             name: 'projects_with_centroid',
-            url: `${mapswipeApi}projects/projects_centroid.geojson`,
+            url: '/api/projects/projects_centroid.geojson',
             type: 'geojson',
         },
     ];
 
-    const urlResponsePromises = urls.map(async (url) => {
-        const res = await fetch(url.url, { method: 'HEAD' });
-        return {
-            ...url,
-            ok: res.ok,
-            size: Number(res.headers.get('content-length') ?? '0'),
-        };
-    });
+    const fileSizes = await getFileSizes();
+    const urlResponsePromises = urls.map(async (url) => ({
+        ...url,
+        ...url,
+        size: fileSizes?.[url.url] ?? 0,
+    }));
 
     const urlResponses = await Promise.all(urlResponsePromises);
 

--- a/src/utils/requests/fileSizes.ts
+++ b/src/utils/requests/fileSizes.ts
@@ -1,0 +1,48 @@
+import util from 'util';
+import fs from 'fs';
+import Papa from 'papaparse';
+import { listToMap } from '@togglecorp/fujs';
+
+import {
+    memoize,
+    timeIt,
+} from 'utils/common';
+
+export type FileSize = {
+    endpoints: string;
+    size_bytes: number;
+};
+
+const readFile = util.promisify(fs.readFile);
+
+const getFileSizes = memoize(async () => {
+    const cacheFileContent = await timeIt(
+        'overall_endpoints',
+        'read cache from disk',
+        () => readFile('cache/overall-endpoints.csv'),
+    );
+    const parsedContent = await new Promise((resolve, reject) => {
+        Papa.parse(cacheFileContent.toString(), {
+            delimiter: ',',
+            newline: '\r\n',
+            header: true,
+            complete: (results: any) => {
+                resolve(results);
+            },
+            error: (error: any) => {
+                reject(error);
+            },
+        });
+    });
+    const fileSizesByEndpoint = (parsedContent as any).data as FileSize[];
+    if (fileSizesByEndpoint.length <= 0) {
+        return undefined;
+    }
+    return listToMap(
+        fileSizesByEndpoint,
+        (item) => item.endpoints,
+        (item) => item.size_bytes,
+    );
+});
+
+export default getFileSizes;

--- a/src/utils/requests/projectCentroids.ts
+++ b/src/utils/requests/projectCentroids.ts
@@ -1,10 +1,15 @@
+import util from 'util';
+import fs from 'fs';
+
 import {
+    timeIt,
     memoize,
     ProjectStatus,
     ProjectType,
     parseProjectName,
 } from 'utils/common';
-import cachedRequest from 'utils/cachedJsonRequest';
+
+const readFile = util.promisify(fs.readFile);
 
 interface CommonProperties {
     idx: number;
@@ -65,12 +70,12 @@ export interface ProjectResponse {
 }
 
 const getProjectCentroids = memoize(async (): Promise<ProjectResponse> => {
-    const mapswipeApi = process.env.MAPSWIPE_API_ENDPOINT;
-
-    const projects = await cachedRequest<RawProjectResponse>(
-        `${mapswipeApi}projects/projects_centroid.geojson`,
-        'projects_centroid.geojson',
+    const cacheFileContent = await timeIt(
+        'project_centriods',
+        'read cache from disk',
+        () => readFile('cache/projects_centroid.geojson'),
     );
+    const projects = JSON.parse(cacheFileContent.toString()) as RawProjectResponse;
 
     const filteredProjects = {
         ...projects,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2539,6 +2539,11 @@ comma-separated-tokens@^2.0.0:
   resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz#4e89c9458acb61bc8fef19f4529973b2392839ee"
   integrity sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==
 
+commander@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
+  integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
+
 commander@~10.0.0:
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
@@ -2636,7 +2641,7 @@ cross-fetch@^3.1.5:
   dependencies:
     node-fetch "2.6.7"
 
-cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
@@ -2971,6 +2976,14 @@ entities@^4.2.0, entities@^4.4.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
+
+env-cmd@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/env-cmd/-/env-cmd-10.1.0.tgz#c7f5d3b550c9519f137fdac4dd8fb6866a8c8c4b"
+  integrity sha512-mMdWTT9XKN7yNth/6N6g2GuKuJTsKMDHlQFUDacb/heQRRWOTIZ42t1rMHnQu4jYxU1ajdTeJM+9eEETlqToMA==
+  dependencies:
+    commander "^4.0.0"
+    cross-spawn "^7.0.0"
 
 eol@^0.9.1:
   version "0.9.1"


### PR DESCRIPTION
## Addresses Deployment using gh-pages

- Do `Clean-up` and merge after https://github.com/mapswipe/community-website/pull/108
- Run on push & daily.
> NOTE: Using https://mapswipe.togglecorp.com/ for custom domain for now

## Changes

- Add GH deployment workflow using `release` branch

## Clean-up
- Check and remove `TODO`

## TODO
- [x] Create a new team https://github.com/orgs/mapswipe/teams/website-maintainers
- [x] Add https://github.com/orgs/mapswipe/teams/website-maintainers to have access to push to `release` branch
- [ ] Migrate from mapswipe.togglecorp.com to mapswipe.org

## This PR doesn't introduce any

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] codegen errors
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
- [x] conflict markers

## This PR includes

- [ ] Translation