### PR TITLE
Define release in CD for schedule jobs

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,7 +4,8 @@ name: CD
 on:
   push:
     branches:
-      - release
+      - main
+
   schedule:
     # Runs "At 00:01. every day" (see https://crontab.guru)
     - cron: '1 0 * * *'
@@ -15,7 +16,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # NOTE: This uses default branch which is `main`
       - uses: actions/checkout@v3
+
       - uses: actions/setup-node@v3
         with:
           node-version: '18.x'


### PR DESCRIPTION
**NOTE: Please merge this to main to take effect for scheduled task**

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
```
Scheduled workflows run on the latest commit on the default or base branch.
```
We are now using the default branch `main` for manual+scheduled builds