### PR TITLE
Add tooltips for icons and a link

### DIFF
--- a/public/locales/en/home.json
+++ b/public/locales/en/home.json
@@ -29,6 +29,7 @@
   "get-involved-link": "Get involved",
   "news-and-updates-title": "News & updates",
   "date": "{{date, datetime}}",
+  "see-more-pages": "See all blog posts",
   "partners": "Partners",
   "missing-maps": "Missing maps logo",
   "missing-map-description": "MapSwipe is part of the Missing Maps Project and is managed by a volunteer-led team with support from  these organizations."

--- a/public/locales/ne/home.json
+++ b/public/locales/ne/home.json
@@ -29,6 +29,7 @@
   "get-involved-link": "संलग्न ",
   "news-and-updates-title": "समाचार र अपडेटहरू",
   "date": "{{date, datetime}}",
+  "see-more-pages": "",
   "partners": "साझेदारहरू",
   "missing-maps": "Missing maps logo",
   "missing-map-description": "MapSwipe Missing Maps परियोजना को अंश हो र यसको व्यवस्थापन स्वयंसेवकको नेतृत्वमा रहेको टोली र संस्थाहरूको समर्थनमा गरिन्छ।"

--- a/src/components/Tag/index.tsx
+++ b/src/components/Tag/index.tsx
@@ -29,6 +29,7 @@ export interface Props {
     variant?: Variant;
     spacing?: Spacing;
     children?: React.ReactNode;
+    tooltip?: string;
 }
 
 function Tag(props: Props) {
@@ -38,10 +39,12 @@ function Tag(props: Props) {
         variant = 'primary',
         spacing = 'medium',
         className,
+        tooltip,
     } = props;
 
     return (
         <div
+            title={tooltip}
             className={_cs(
                 className,
                 styles.tag,

--- a/src/pages/[locale]/data/index.tsx
+++ b/src/pages/[locale]/data/index.tsx
@@ -815,6 +815,7 @@ function Data(props: Props) {
                                     <div className={styles.bottomTags}>
                                         {project.region && (
                                             <Tag
+                                                tooltip="Location"
                                                 className={styles.tag}
                                                 icon={<IoLocationOutline />}
                                                 variant="transparent"
@@ -824,6 +825,7 @@ function Data(props: Props) {
                                         )}
                                         {project.requestingOrganization && (
                                             <Tag
+                                                tooltip="Requesting organization"
                                                 className={styles.tag}
                                                 icon={<IoFlag />}
                                                 variant="transparent"
@@ -834,6 +836,7 @@ function Data(props: Props) {
                                         <div className={styles.projectDetailsRow}>
                                             {project.created && (
                                                 <Tag
+                                                    tooltip="Created date"
                                                     className={styles.tag}
                                                     icon={<IoCalendarClearOutline />}
                                                     variant="transparent"
@@ -843,6 +846,7 @@ function Data(props: Props) {
                                             )}
                                             {project.number_of_users && (
                                                 <Tag
+                                                    tooltip="Project contributors"
                                                     className={styles.tag}
                                                     icon={<IoPerson />}
                                                     variant="transparent"

--- a/src/pages/[locale]/index.tsx
+++ b/src/pages/[locale]/index.tsx
@@ -334,6 +334,14 @@ function Home(props: Props) {
                         </Link>
                     </Card>
                 ))}
+                <div className={styles.sectionDescription}>
+                    <Link
+                        href="/[locale]/blogs"
+                        variant="underline"
+                    >
+                        {t('see-more-pages')}
+                    </Link>
+                </div>
             </Section>
             <Section
                 className={styles.partners}

--- a/src/pages/[locale]/projects/[id].tsx
+++ b/src/pages/[locale]/projects/[id].tsx
@@ -302,6 +302,7 @@ function Project(props: Props) {
                         <div className={styles.bottomTags}>
                             {region && (
                                 <Tag
+                                    tooltip="Location"
                                     className={styles.heroTag}
                                     icon={<IoLocationOutline />}
                                     variant="transparent"
@@ -311,6 +312,7 @@ function Project(props: Props) {
                             )}
                             {requestingOrganization && (
                                 <Tag
+                                    tooltip="Requesting organization"
                                     className={styles.heroTag}
                                     icon={<IoFlag />}
                                     variant="transparent"
@@ -320,6 +322,7 @@ function Project(props: Props) {
                             )}
                             {created && (
                                 <Tag
+                                    tooltip="Created date"
                                     className={styles.heroTag}
                                     icon={<IoCalendarClearOutline />}
                                     variant="transparent"

--- a/src/pages/[locale]/styles.module.css
+++ b/src/pages/[locale]/styles.module.css
@@ -253,6 +253,12 @@
                 grid-row: auto / span 2;
             }
 
+            .sectionDescription {
+                grid-column: 1 / -1;
+                text-align: center;
+                font-size: var(--font-size-medium);
+            }
+
             @media screen and (max-width: 800px) {
                 grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
 


### PR DESCRIPTION
## Addresses:
- Issue: https://github.com/mapswipe/community-website/issues/160#issue-1792889275
- Issue: https://github.com/mapswipe/community-website/issues/159#issue-1790837026

## Changes:
- Add tooltips for icons and add a link in the blogs page to see all blogs

## This PR doesn't introduce any
- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] codegen errors
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
- [x] conflict markers

## This PR includes

- [ ] Translation
