### PR TITLE
Update v2 to v4

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,15 +17,15 @@ jobs:
 
     steps:
       # NOTE: This uses default branch which is `main`
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: '18.x'
           cache: 'yarn'
           cache-dependency-path: 'yarn.lock'
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: data-cache
         with:
           path: cache
@@ -55,7 +55,7 @@ jobs:
           MAPSWIPE_BUILD_DATE: ${{ env.MAPSWIPE_API_LAST_MODIFIED_EPOCH }}
 
       - name: Upload GH artifacts
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: out/
 
@@ -76,4 +76,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages 🚀
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,14 @@ jobs:
     name: Lint + Type Checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '18.x'
           cache: 'yarn'
 
       # Pre-commit
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
       - name: Install pre-commit
         run: pip install pre-commit
 


### PR DESCRIPTION
- Addresses ![image](https://github.com/user-attachments/assets/7e2b6b91-5445-4424-9d17-cafc91522294)
  - https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
  - https://github.com/mapswipe/website/actions/runs/13125566819



## Changes

- Upgrade all used actions to their latest versions

## This PR doesn't introduce any

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] codegen errors
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
- [x] conflict markers

## This PR includes

- [ ] Translation
