### PR TITLE
fix: use firebaseId for projects in project page

### DIFF
--- a/scripts/fetchData.ts
+++ b/scripts/fetchData.ts
@@ -133,6 +133,7 @@ const query = gql`
                     fileSize
                 }
                 name
+                firebaseId
                 image {
                     id
                     file {

--- a/src/pages/[locale]/data/index.tsx
+++ b/src/pages/[locale]/data/index.tsx
@@ -118,6 +118,7 @@ export const getStaticProps: GetStaticProps = async (context) => {
         id: feature.id ?? '',
         projectType: feature.projectType,
         name: feature.name,
+        firebaseId: feature.firebaseId,
         status: feature.status ?? null,
         region: feature.region ?? null,
         requestingOrganizationId: feature.requestingOrganization?.id ?? null,
@@ -812,7 +813,7 @@ function Data(props: Props) {
                         <Link
                             className={styles.cardLink}
                             key={project.id}
-                            href={`/[locale]/projects/${project.id}`}
+                            href={`/[locale]/projects/${project.firebaseId}`}
                         >
                             <Card
                                 className={styles.project}

--- a/src/pages/[locale]/projects/[id].tsx
+++ b/src/pages/[locale]/projects/[id].tsx
@@ -56,7 +56,7 @@ async function getProjectData(id: string) {
     const projects = (
         data as AllDataQuery
     )?.publicProjects?.results as unknown as PublicProjects;
-    return projects?.find((item) => String(item.id) === id);
+    return projects?.find((item) => String(item.firebaseId) === id);
 }
 
 const X_AXIS_HEIGHT = 20;
@@ -862,9 +862,9 @@ export const getStaticPaths: GetStaticPaths = async () => {
     const projects = await getAllProjects() ?? [];
 
     const pathsWithParams = projects.flatMap(
-        (project: { id: string }) => i18nextConfig.i18n.locales.map((lng: string) => ({
+        (project: { firebaseId: string }) => i18nextConfig.i18n.locales.map((lng: string) => ({
             params: {
-                id: project.id.toString(),
+                id: project.firebaseId.toString(),
                 locale: lng,
             },
         })),


### PR DESCRIPTION
## Changes

- Use firebaseId for projects in project page

## This PR doesn't introduce any

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] codegen errors
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
- [x] conflict markers

## This PR includes

- [x] Translation