### PR TITLE
fix(builddate):display data last fetched time in UTC

### DIFF
--- a/src/pages/[locale]/data/index.tsx
+++ b/src/pages/[locale]/data/index.tsx
@@ -713,7 +713,8 @@ function Data(props: Props) {
                         {t('data-last-fetched', {
                             date: (new Date(Number(buildDate))),
                             dateStyle: 'medium',
-                            timeStyle: 'medium',
+                            timeStyle: 'long',
+                            timeZone: 'UTC',
                         })}
                         <br />
                         {t('explore-section-heading-description')}


### PR DESCRIPTION
## Changes

- Display data last fetched time in UTC

## This PR doesn't introduce any

- [X] temporary files, auto-generated files or secret keys
- [X] build works
- [X] eslint issues
- [X] typescript issues
- [X] codegen errors
- [X] `console.log` meant for debugging
- [X] typos
- [X] unwanted comments
- [X] conflict markers

## This PR includes

- [ ] Translation
